### PR TITLE
ci: fix ghcr.io container pushing

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -65,12 +65,14 @@ jobs:
 
       - name: Docker meta
         id: meta
+        if: github.event_name != 'pull_request'
         uses: docker/metadata-action@v4
         with:
           images: name=ghcr.io/${{ github.repository }}/build${{ matrix.container_flavor }}-v${{ env.BUILDBOT_VERSION }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -78,6 +80,7 @@ jobs:
 
       - name: Build container again and push it
         uses: docker/build-push-action@v4
+        if: github.event_name != 'pull_request'
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -67,7 +67,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: name=ghcr.io/${{ github.actor }}/build${{ matrix.container_flavor }}-v${{ env.BUILDBOT_VERSION }}
+          images: name=ghcr.io/${{ github.repository }}/build${{ matrix.container_flavor }}-v${{ env.BUILDBOT_VERSION }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2


### PR DESCRIPTION
Attempt to fix following:

```
 #11 ERROR: denied: permission_denied: The requested installation does not exist.
 ------
  > pushing ghcr.io/ynezz/buildworker-v3.5.0:master with docker:
 ------
 ERROR: denied: permission_denied: The requested installation does not exist.
 Error: buildx failed with: ERROR: denied: permission_denied: The requested installation does not exist.
```

References: https://github.com/openwrt/buildbot/actions/runs/4971701948/jobs/8899889081#step:9:191