### PR TITLE
phase1: workaround gitverify 1st build failures on fresh workers

### DIFF
--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -725,6 +725,16 @@ for target in targets:
 		haltOnFailure = True,
 	))
 
+	# workaround for https://github.com/openwrt/buildbot/issues/5
+	factory.addStep(Git(
+		name = "git me once more please",
+		repourl = repo_url,
+		mode = 'full',
+		method = 'fresh',
+		locks = NetLockDl,
+		haltOnFailure = True,
+	))
+
 	# update remote refs
 	factory.addStep(ShellCommand(
 		name = "fetchrefs",


### PR DESCRIPTION
Currently every 1st build on ephemeral build worker results in the failure of the `gitverify` build step as the stock buildbot Git() build step for some reasons just clones the Git repository into detached HEAD state.

On the 2nd build using the same build worker Git() checkouts the branch and thus makes `gitverify` step happy and the builds then continues normally.

This needs to be fixed properly, either by adjusting the `gitverify` check or adding suitable `mode` into Git() build step, but this needs more time and testing.

So for now, lets simply workaround that issue by running Git() step two times.

References: #5