### PR TITLE
docker,worker: install g++-multilib

### DIFF
--- a/docker/buildworker/Dockerfile
+++ b/docker/buildworker/Dockerfile
@@ -18,6 +18,7 @@ RUN \
 		ccache \
 		curl \
 		gawk \
+		g++-multilib \
 		gcc-multilib \
 		genisoimage \
 		git-core \


### PR DESCRIPTION
(Moved over from https://gitlab.com/openwrt/buildbot/-/merge_requests/11) Cc @aloisklink

From [openwrt/docker@5484951][1] (GitHub PR [#89][2]):

Node fails to cross-compile from a 64-bit build machine to 32-bit host with the following error:

```
  In file included from /usr/include/c++/8/memory:62,
  from ../deps/v8/src/libplatform/default-foreground-task-runner.h:8,
  from ../deps/v8/src/libplatform/default-foreground-task-runner.cc:5:
  /usr/include/c++/8/bits/stl_algobase.h:59:10: fatal error: bits/c++config.h:
    No such file or directory
  #include <bits/c++config.h>
          ^~~~~~~~~~~~~~~~~~
  compilation terminated.
```

On Debian, `g++-multilib` can be installed to fix this.

[1]: https://gitlab.com/openwrt/docker/-/commit/54849510d7802028b94757051cca6d004a9ca1d1
[2]: https://github.com/openwrt/docker/pull/89

Fixes: https://github.com/openwrt/packages/issues/18476
Fixes: https://forum.openwrt.org/t/why-arent-the-node-and-node-npm-packages-available-on-arm-cortex-a9-vfpv3-d16-in-22-03-2/142722