### PR TITLE
phase1: cleanup redundant steps

### DIFF
--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -754,19 +754,6 @@ for target in targets:
 		haltOnFailure = True,
 	))
 
-	factory.addStep(ShellCommand(
-		name = "rmtmp",
-		description = "Remove tmp folder",
-		command=["rm", "-rf", "tmp/"],
-	))
-
-	# feed
-	factory.addStep(ShellCommand(
-		name = "rmfeedlinks",
-		description = "Remove feed symlinks",
-		command=["rm", "-rf", "package/feeds/"],
-	))
-
 	factory.addStep(StringDownload(
 		name = "ccachecc",
 		s = '#!/bin/sh\nexec ${CCACHE} ${CCC} "$@"\n',
@@ -813,12 +800,6 @@ for target in targets:
 		name = "newconfig",
 		descriptionDone = ".config seeded",
 		command = Interpolate("printf 'CONFIG_TARGET_%(kw:target)s=y\\nCONFIG_TARGET_%(kw:target)s_%(kw:subtarget)s=y\\nCONFIG_SIGNED_PACKAGES=%(kw:usign:#?|y|n)s\\n' >> .config", target=ts[0], subtarget=ts[1], usign=GetUsignKey),
-	))
-
-	factory.addStep(ShellCommand(
-		name = "delbin",
-		description = "Removing output directory",
-		command = ["rm", "-rf", "bin/"],
 	))
 
 	factory.addStep(ShellCommand(


### PR DESCRIPTION
These 3 rm steps are unnecessary since these folders are already cleaned by the Git() step. Thus reduce clutter in already pretty busy Factory.