### PR TITLE
phase1: satisfy getver.sh requirements

### DIFF
--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -744,6 +744,16 @@ for target in targets:
 		haltOnFailure = True,
 	))
 
+	# getver.sh requires local branches to track upstream otherwise version computation fails.
+	# Git() does not set tracking branches when cloning or switching, so work around this here
+	factory.addStep(ShellCommand(
+		name = "trackupstream",
+		description = "Setting upstream branch",
+		descriptionDone = "getver.sh is happy now",
+		command = ["git", "branch", "-u", Interpolate("origin/%(prop:branch)s")],
+		haltOnFailure = True,
+	))
+
 	# Verify that Git HEAD points to a tag or branch
 	# Ref: https://web.archive.org/web/20190729224316/http://lists.infradead.org/pipermail/openwrt-devel/2019-June/017809.html
 	factory.addStep(ShellCommand(


### PR DESCRIPTION
scripts/getver.sh requires upstream branch tracking to correctly compute revision number. Buildbot Git() step does not set branch tracking as it checks out individual commits and then reset the target branch to it, so in order for getver.sh to work, this workaround forcefully sets the upstream branch.

This fixes malformed version code in filenames as observed on openwrt-23.05:

r23001+3-38c150612c
instead of:
r23004-7f0db09513