### PR TITLE
phase1: dlprune: fix cannot delete ‘dl/’: Not a directory

### DIFF
--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -881,7 +881,7 @@ for target in targets:
 		name = "dlprune",
 		description = "Pruning dl/",
 		descriptionDone = "dl/ pruned",
-		command = 'find dl/ -atime +15 -delete -print',
+		command = 'find dl/ -mindepth 1 -atime +15 -delete -print',
 		logEnviron = False,
 	))
 


### PR DESCRIPTION
dlprune currently fails [with following error](https://buildbot.staging.openwrt.org/images/#/builders/101/builds/10):

```
 find: cannot delete ‘dl/’: Not a directory
```

![image](https://github.com/openwrt/buildbot/assets/43848/4f27e124-efab-4703-a67f-846bd3f4aba8)

Initial idea was to delete only files and not the download directory itself, so lets adjust the find command accordingly.

Fixes: 68b20ed67b5e ("phase1: prune unused files from dl/")