### PR TITLE
docker,worker: install pyelftools

### DIFF
--- a/docker/buildworker/Dockerfile
+++ b/docker/buildworker/Dockerfile
@@ -45,6 +45,7 @@ RUN \
 RUN pip3 install -U pip
 RUN pip3 install \
 		"buildbot-worker==$BUILDBOT_VERSION" \
+  		pyelftools \
 		pyOpenSSL \
 		service_identity
 


### PR DESCRIPTION
UBoot version of at least 2023.07.02 that use binman also have a dependency of pyelftools on the build host.