### PR TITLE
ci: generic improvement and cleanup of workflow

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   BUILDBOT_VERSION: 3.8.0
+  GITHUB_SHA_LEN: 8
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -63,7 +64,7 @@ jobs:
 
       - name: Environment variables
         run: |
-          echo "GIT_SHA_SHORT=${GITHUB_SHA::8}" >> $GITHUB_ENV
+          echo "GIT_SHA_SHORT=${GITHUB_SHA::${{ env.GITHUB_SHA_LEN }}}" >> $GITHUB_ENV
 
       - name: Build container and export it to local Docker
         uses: docker/build-push-action@v4

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Stylecheck with black
         run: black phase1/master.cfg
 
-  build-test-push:
-    name: Build, test and push containers
+  build-test:
+    name: Build and Test container
     runs-on: ubuntu-latest
     needs: test-lint
 
@@ -86,16 +86,39 @@ jobs:
           docker logs test-${{ matrix.container_flavor }} | tee ${{ matrix.container_flavor }}.log
           grep "${{ matrix.container_verify_string }}" ${{ matrix.container_flavor }}.log
 
+  deploy:
+    name: Push Container
+    if: github.event_name != 'pull_request' || github.repository_owner != 'openwrt'
+    runs-on: ubuntu-latest
+    needs: build-test
+
+    environment: production
+
+    permissions:
+      packages: write
+
+    strategy:
+      matrix:
+        container_flavor:
+          - master
+          - worker
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Environment variables
+        run: |
+          echo "GIT_SHA_SHORT=${GITHUB_SHA::${{ env.GITHUB_SHA_LEN }}}" >> $GITHUB_ENV
+
       - name: Docker meta
         id: meta
-        if: github.event_name != 'pull_request' || github.repository_owner != 'openwrt'
         uses: docker/metadata-action@v4
         with:
           images: name=ghcr.io/${{ github.repository }}/build${{ matrix.container_flavor }}-v${{ env.BUILDBOT_VERSION }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
-        if: github.event_name != 'pull_request' || github.repository_owner != 'openwrt'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -103,7 +126,6 @@ jobs:
 
       - name: Build container again and push it
         uses: docker/build-push-action@v4
-        if: github.event_name != 'pull_request' || github.repository_owner != 'openwrt'
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -54,9 +54,12 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'pull_request' }}
       matrix:
-        container_flavor:
-          - master
-          - worker
+        include:
+          - container_flavor: master
+            container_verify_string: "buildmaster configured in /master"
+          - container_flavor: worker
+            container_test_command: "--env BUILDWORKER_NAME=X --env BUILDWORKER_PASSWORD=Y"
+            container_verify_string: "worker configured in /builder"
 
     steps:
       - name: Checkout
@@ -76,21 +79,12 @@ jobs:
             BUILDBOT_VERSION=${{ env.BUILDBOT_VERSION }}
             OPENWRT_VERSION=${{ env.GIT_SHA_SHORT }}
 
-      - name: Test master Docker container
-        if: matrix.container_flavor == 'master'
+      - name: Test ${{ matrix.container_flavor }} Docker container
         run: |
-          docker run --detach --name test-master local/master
+          docker run --detach ${{ matrix.container_test_command }} --name test-${{ matrix.container_flavor }} local/${{ matrix.container_flavor }}
           sleep 5
-          docker logs test-master | tee master.log
-          grep "buildmaster configured in /master" master.log
-
-      - name: Test worker Docker container
-        if: matrix.container_flavor == 'worker'
-        run: |
-          docker run --detach --env BUILDWORKER_NAME=X --env BUILDWORKER_PASSWORD=Y --name test-worker local/worker
-          sleep 5
-          docker logs test-worker | tee worker.log
-          grep "worker configured in /builder" worker.log
+          docker logs test-${{ matrix.container_flavor }} | tee ${{ matrix.container_flavor }}.log
+          grep "${{ matrix.container_verify_string }}" ${{ matrix.container_flavor }}.log
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
Improve and refactor some part of the workflow to better organize it and use github deploy feature.

The final result on a running push is the following

![Screenshot 2023-11-14 144440](https://github.com/openwrt/buildbot/assets/20289090/147cb44e-3dc3-4b75-a1d6-d4771a8fee5a)

---

@ynezz my only question is what we should use as tag... Is "production" ok? We can use whatever we want... Also buildbot.

Aside from this, it's just a cleanup and improvement.

Also also... Should we change the short version for git to 12? Using 8 has been deprecated... No idea if it does cause problems.