### PR TITLE
phase2: update default sdk pattern to a more relaxed pattern

### DIFF
--- a/docker/config.ini
+++ b/docker/config.ini
@@ -36,7 +36,7 @@ source_url = upload@rsync-server::data/src
 source_password = secret
 sdk_url = upload@rsync-server::data/bin/targets
 sdk_password = secret
-sdk_pattern = openwrt-sdk-*.tar.xz
+sdk_pattern = openwrt-sdk-*.tar.*
 
 [gpg]
 key = -----BEGIN PGP PRIVATE KEY BLOCK-----

--- a/phase2/config.ini.example
+++ b/phase2/config.ini.example
@@ -29,7 +29,7 @@ source_url = user@example.org::upload-sources
 source_password = example2
 sdk_url = user@example.org::download-binary
 sdk_password = example3
-sdk_pattern = openwrt-sdk-*.tar.xz
+sdk_pattern = openwrt-sdk-*.tar.*
 
 [gpg]
 key = -----BEGIN PGP PRIVATE KEY BLOCK-----

--- a/phase2/master.cfg
+++ b/phase2/master.cfg
@@ -115,7 +115,7 @@ if ini.has_option("rsync", "source_url"):
 
 rsync_sdk_url = None
 rsync_sdk_key = None
-rsync_sdk_pat = "openwrt-sdk-*.tar.xz"
+rsync_sdk_pat = "openwrt-sdk-*.tar.*"
 
 if ini.has_option("rsync", "sdk_url"):
 	rsync_sdk_url = ini.get("rsync", "sdk_url")


### PR DESCRIPTION
Update default sdk pattern to a more relaxed pattern to make it future proof if in the future the compression extension will change again.

Needed currently with the migration from .xz to .zst.

---

@ynezz  @f00b4r0 Can you guys also update the config.ini to point to the new pattern (if that is defined in our config?)

Or eventually if it's not and we can't push a new release, can we add the entry since that is configurable?