### PR TITLE
phase1: remove kmods in target packages if archive is enabled

### DIFF
--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -588,6 +588,10 @@ def IsKmodArchiveAndRsyncEnabled(step):
     return bool(IsKmodArchiveEnabled(step) and branches[branch].get("bin_url"))
 
 
+def IsRemoteShaSumsAvailable(step):
+    return step.getProperty("have_remote_shasums")
+
+
 def GetBaseVersion(branch):
     if re.match(r"^[^-]+-[0-9]+\.[0-9]+$", branch):
         return branch.split("-")[1]
@@ -1383,6 +1387,78 @@ def prepareFactory(target):
         )
     )
 
+    # download remote sha256sums to 'target-sha256sums'
+    factory.addStep(
+        ShellCommandAndSetProperty(
+            name="target-sha256sums",
+            description="Fetching remote sha256sums for target",
+            descriptionDone="Remote sha256sums for target fetched",
+            command=["rsync", Interpolate("-z%(prop:rsync_ipv4:+4)s")]
+            + rsync_defopts
+            + [
+                Interpolate(
+                    "%(kw:url)s/%(kw:prefix)stargets/%(kw:target)s/%(kw:subtarget)s/sha256sums",
+                    url=GetRsyncParams.withArgs("bin", "url"),
+                    target=target,
+                    subtarget=subtarget,
+                    prefix=GetVersionPrefix,
+                ),
+                "target-sha256sums",
+            ],
+            env={
+                "RSYNC_PASSWORD": Interpolate(
+                    "%(kw:key)s", key=GetRsyncParams.withArgs("bin", "key")
+                )
+            },
+            property="have_remote_shasums",
+            logEnviron=False,
+            haltOnFailure=False,
+            flunkOnFailure=False,
+            warnOnFailure=False,
+            doStepIf=util.Transform(bool, GetRsyncParams.withArgs("bin", "url")),
+        )
+    )
+
+    factory.addStep(
+        ShellCommand(
+            name="target-sha256sums_kmodsparse",
+            description="Extract kmods from remote sha256sums",
+            descriptionDone="Kmods extracted",
+            command="sed \"/ \\*kmods\\//! d\" target-sha256sums | tee target-sha256sums-kmods",
+            haltOnFailure=False,
+            doStepIf=IsRemoteShaSumsAvailable,
+        )
+    )
+
+    factory.addStep(
+        ShellCommand(
+            name="mergesha256sum",
+            description="Merge sha256sums kmods with sha256sums",
+            descriptionDone="Sha256sums merged",
+            command=[
+                "sort",
+                "-t", " ",
+                "-k", 2,
+                "-u",
+                Interpolate(
+                    "bin/targets/%(kw:target)s/%(kw:subtarget)s%(prop:libc)s/sha256sums",
+                    target=target,
+                    subtarget=subtarget,
+                ),
+                "target-sha256sums-kmods",
+                "-o",
+                Interpolate(
+                    "bin/targets/%(kw:target)s/%(kw:subtarget)s%(prop:libc)s/sha256sums",
+                    target=target,
+                    subtarget=subtarget,
+                ),
+            ],
+            env={"LC_ALL": "C"},
+            haltOnFailure=False,
+            doStepIf=IsRemoteShaSumsAvailable,
+        )
+    )
+
     # sign
     factory.addStep(
         MasterShellCommand(
@@ -1537,37 +1613,6 @@ def prepareFactory(target):
             haltOnFailure=True,
             logEnviron=False,
             locks=NetLockUl,
-            doStepIf=util.Transform(bool, GetRsyncParams.withArgs("bin", "url")),
-        )
-    )
-
-    # download remote sha256sums to 'target-sha256sums'
-    factory.addStep(
-        ShellCommand(
-            name="target-sha256sums",
-            description="Fetching remote sha256sums for target",
-            descriptionDone="Remote sha256sums for target fetched",
-            command=["rsync", Interpolate("-z%(prop:rsync_ipv4:+4)s")]
-            + rsync_defopts
-            + [
-                Interpolate(
-                    "%(kw:url)s/%(kw:prefix)stargets/%(kw:target)s/%(kw:subtarget)s/sha256sums",
-                    url=GetRsyncParams.withArgs("bin", "url"),
-                    target=target,
-                    subtarget=subtarget,
-                    prefix=GetVersionPrefix,
-                ),
-                "target-sha256sums",
-            ],
-            env={
-                "RSYNC_PASSWORD": Interpolate(
-                    "%(kw:key)s", key=GetRsyncParams.withArgs("bin", "key")
-                )
-            },
-            logEnviron=False,
-            haltOnFailure=False,
-            flunkOnFailure=False,
-            warnOnFailure=False,
             doStepIf=util.Transform(bool, GetRsyncParams.withArgs("bin", "url")),
         )
     )

--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -1252,23 +1252,6 @@ def prepareFactory(target):
 
     factory.addStep(
         ShellCommand(
-            name="pkgindex",
-            description="Indexing packages",
-            descriptionDone="Packages indexed",
-            command=[
-                "make",
-                Interpolate("-j%(prop:nproc:-1)s"),
-                "package/index",
-                "V=s",
-                "CONFIG_SIGNED_PACKAGES=",
-            ],
-            env=MakeEnv(),
-            haltOnFailure=True,
-        )
-    )
-
-    factory.addStep(
-        ShellCommand(
             name="images",
             description="Building and installing images",
             descriptionDone="Images built and installed",
@@ -1305,17 +1288,6 @@ def prepareFactory(target):
 
     factory.addStep(
         ShellCommand(
-            name="checksums",
-            description="Calculating checksums",
-            descriptionDone="Checksums calculated",
-            command=["make", "-j1", "checksum", "V=s"],
-            env=MakeEnv(),
-            haltOnFailure=True,
-        )
-    )
-
-    factory.addStep(
-        ShellCommand(
             name="kmoddir",
             descriptionDone="Kmod directory created",
             command=[
@@ -1339,6 +1311,7 @@ def prepareFactory(target):
             descriptionDone="Kmod archive prepared",
             command=[
                 "rsync",
+                "--remove-source-files",
                 "--include=/kmod-*.ipk",
                 "--include=/kmod-*.apk",
                 "--exclude=*",
@@ -1356,6 +1329,23 @@ def prepareFactory(target):
             ],
             haltOnFailure=True,
             doStepIf=IsKmodArchiveEnabled,
+        )
+    )
+
+    factory.addStep(
+        ShellCommand(
+            name="pkgindex",
+            description="Indexing packages",
+            descriptionDone="Packages indexed",
+            command=[
+                "make",
+                Interpolate("-j%(prop:nproc:-1)s"),
+                "package/index",
+                "V=s",
+                "CONFIG_SIGNED_PACKAGES=",
+            ],
+            env=MakeEnv(),
+            haltOnFailure=True,
         )
     )
 
@@ -1379,6 +1369,17 @@ def prepareFactory(target):
             env=MakeEnv(),
             haltOnFailure=True,
             doStepIf=IsKmodArchiveEnabled,
+        )
+    )
+
+    factory.addStep(
+        ShellCommand(
+            name="checksums",
+            description="Calculating checksums",
+            descriptionDone="Checksums calculated",
+            command=["make", "-j1", "checksum", "V=s"],
+            env=MakeEnv(),
+            haltOnFailure=True,
         )
     )
 

--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -1664,6 +1664,7 @@ def prepareFactory(target):
             command=[
                 "../rsync.sh",
                 "--exclude=/kmods/",
+                "--exclude=/kmods/**",
                 "--files-from=rsynclist",
                 "--delay-updates",
                 "--partial-dir=.~tmp~%s~%s" % (target, subtarget),

--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -17,6 +17,7 @@ from buildbot import locks
 from buildbot.data import resultspec
 from buildbot.changes.gitpoller import GitPoller
 from buildbot.config import BuilderConfig
+from buildbot.process import buildstep
 from buildbot.plugins import reporters
 from buildbot.plugins import schedulers
 from buildbot.plugins import steps
@@ -756,6 +757,37 @@ c["builders"].append(
         name="00_force_build", workername="__local_force_build", factory=force_factory
     )
 )
+
+
+# CUSTOM CLASS
+
+# Extension of ShellCommand and sets in property:
+# - True: the command succeded
+# - False: the command failed
+class ShellCommandAndSetProperty(buildstep.ShellMixin, buildstep.BuildStep):
+    name = "shellandsetproperty"
+    renderables = ['property']
+
+    def __init__(
+        self,
+        property=None,
+        **kwargs,
+    ):
+        kwargs = self.setupShellMixin(kwargs)
+
+        self.property = property
+
+        super().__init__(**kwargs)
+
+    @defer.inlineCallbacks
+    def run(self):
+        cmd = yield self.makeRemoteShellCommand()
+
+        yield self.runCommand(cmd)
+
+        self.setProperty(self.property, not cmd.didFail(), "ShellCommandAndSetProperty Step")
+
+        return cmd.results()
 
 
 # NB the phase1 build factory assumes workers are single-build only

--- a/scripts/signall.sh
+++ b/scripts/signall.sh
@@ -90,6 +90,8 @@ if [ -n "$APKSIGNKEY" ]; then
 
 		grep 'packages\.adb' sha256sums | while IFS= read -r line; do
 			filename="${line#*' *'}"
+			# Skip updating hash of previous kmods/ if not found in sign tar (already signed)
+			[ ! -f "$filename" ] && [[ "$filename" == kmods/* ]] && continue
 			escaped_filename="${filename//\//\\\/}"
 			escaped_filename="${escaped_filename//&/\\&}"
 			checksum_output=$(sha256sum --binary -- "$filename")


### PR DESCRIPTION
OPKG gets confused if kmod packages are present in both, target packages as well as kernel version specific folder.
Remove them from target packages to make opkg pick the kmods from kmod archive folder only.

I didn't test this and I'm not very familiar with buildbot. Just noticing that currently, older snapshots fail to install packages because newer-version kmods from target packages are selected instead of the ones matching the kernel version, so this should be fixed somehow...