### PR TITLE
Revert "Bump buildbot to v3.11.3 release"

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  BUILDBOT_VERSION: 3.11.3
+  BUILDBOT_VERSION: 3.11.1
   GITHUB_SHA_LEN: 8
 
 concurrency:


### PR DESCRIPTION
This reverts commit 44ed9a39fddc4e79ec1276c3e5923766cbe19878 as it breaks GitPoller.

References: https://github.com/buildbot/buildbot/issues/7663