### PR TITLE
phase1: make list of builders configurable

### DIFF
--- a/phase1/config.ini.example
+++ b/phase1/config.ini.example
@@ -45,6 +45,11 @@ config_seed = # Seed configuration
 	CONFIG_CCACHE=n
 	CONFIG_KERNEL_KALLSYMS=y
 	CONFIG_AUTOREMOVE=y
+build_targets = armsr/armv8
+	malta/be
+	mediatek/filogic
+	qualcommax/ipq807x
+	x86/64
 
 [branch openwrt-22.03]
 name = openwrt-22.03

--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -300,47 +300,52 @@ targets = dict()
 
 
 def populateTargets():
-    """fetch a shallow clone of each configured branch in turn:
-    execute dump-target-info.pl and collate the results to ensure
+    for branch in branchNames:
+        populateTargetsForBranch(branch)
+
+
+def populateTargetsForBranch(branch):
+    """fetches a shallow clone for passed `branch` and then
+    executes dump-target-info.pl and collates the results to ensure
     targets that only exist in specific branches get built.
     This takes a while during master startup but is executed only once.
     """
+    targets[branch] = set()
     sourcegit = work_dir + "/source.git"
-    for branch in branchNames:
-        log.msg(f"Populating targets for {branch}, this will take time")
 
-        if os.path.isdir(sourcegit):
-            subprocess.call(["rm", "-rf", sourcegit])
+    log.msg(f"Populating targets for {branch}, this will take time")
 
-        subprocess.call(
-            [
-                "git",
-                "clone",
-                "-q",
-                "--depth=1",
-                "--branch=" + branch,
-                repo_url,
-                sourcegit,
-            ]
-        )
-
-        os.makedirs(sourcegit + "/tmp", exist_ok=True)
-        findtargets = subprocess.Popen(
-            ["./scripts/dump-target-info.pl", "targets"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            cwd=sourcegit,
-        )
-
-        targets[branch] = set()
-        while True:
-            line = findtargets.stdout.readline()
-            if not line:
-                break
-            ta = line.decode().strip().split(" ")
-            targets[branch].add(ta[0])
-
+    if os.path.isdir(sourcegit):
         subprocess.call(["rm", "-rf", sourcegit])
+
+    subprocess.call(
+        [
+            "git",
+            "clone",
+            "-q",
+            "--depth=1",
+            "--branch=" + branch,
+            repo_url,
+            sourcegit,
+        ]
+    )
+
+    os.makedirs(sourcegit + "/tmp", exist_ok=True)
+    findtargets = subprocess.Popen(
+        ["./scripts/dump-target-info.pl", "targets"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        cwd=sourcegit,
+    )
+
+    while True:
+        line = findtargets.stdout.readline()
+        if not line:
+            break
+        ta = line.decode().strip().split(" ")
+        targets[branch].add(ta[0])
+
+    subprocess.call(["rm", "-rf", sourcegit])
 
 
 populateTargets()

--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -93,6 +93,7 @@ def ini_parse_branch(section):
     b["usign_comment"] = section.get("usign_comment", usign_comment)
 
     b["config_seed"] = section.get("config_seed")
+    b["build_targets"] = section.get("build_targets")
 
     b["kmod_archive"] = section.getboolean("kmod_archive", False)
 
@@ -300,8 +301,14 @@ targets = dict()
 
 
 def populateTargets():
+    def buildTargetsConfigured(branch):
+        builders = branches[branch].get("build_targets")
+        return builders and set(filter(None, [t.strip() for t in builders.split("\n")]))
+
     for branch in branchNames:
-        populateTargetsForBranch(branch)
+        targets[branch] = buildTargetsConfigured(branch)
+        if not targets[branch]:
+            populateTargetsForBranch(branch)
 
 
 def populateTargetsForBranch(branch):


### PR DESCRIPTION
Currently we always populate builders (build targets) from the Git tree,
but for staging environment this is usually overkill as we might need
just a bunch of targets, so lets make this configurable.