### PR TITLE
phase1: AnyBranchScheduler: make treeStableTimer configurable

### DIFF
--- a/phase1/config.ini.example
+++ b/phase1/config.ini.example
@@ -19,6 +19,7 @@ password = example
 
 [repo]
 url = https://git.openwrt.org/openwrt/openwrt.git
+tree_stable_timer = 900
 
 # branches should be listed by decreasing build priority order, typically oldest branch first (less build intensive)
 # branch section name should match branch "name" option until signall.sh is reworked

--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -61,6 +61,7 @@ work_dir = os.path.abspath(ini["general"].get("workdir", "."))
 scripts_dir = os.path.abspath("../scripts")
 
 repo_url = ini["repo"].get("url")
+tree_stable_timer = ini["repo"].getint("tree_stable_timer", 15 * 60)
 
 rsync_defopts = ["-v", "--timeout=120"]
 
@@ -509,7 +510,7 @@ c["schedulers"].append(
     AnyBranchScheduler(
         name="all",
         change_filter=util.ChangeFilter(branch=branchNames),
-        treeStableTimer=15 * 60,
+        treeStableTimer=tree_stable_timer,
         builderNames=builderNames,
     )
 )


### PR DESCRIPTION
The AnyBranchScheduler will currently wait for 15 minutes before starting a build.  If new changes are made on the same branch during this interval, the timer will be restarted.

For staging repository we want faster feedback loop, so we're going to use much lower value, thus lets make this configurable and handled via Ansible.