### PR TITLE
phase1: kmodprepare: add apk compat

### DIFF
--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -1306,6 +1306,7 @@ def prepareFactory(target):
             command=[
                 "rsync",
                 "--include=/kmod-*.ipk",
+                "--include=/kmod-*.apk",
                 "--exclude=*",
                 "-va",
                 Interpolate(


### PR DESCRIPTION
Ansuel reported, that with `USE_APK=y` there are no kmods available in the build artifacts, so lets fix it by extending the rsync's include pattern with the `apk` suffix to make it future proof.

Reported-by: Christian Marangi <ansuelsmth@gmail.com>