### PR TITLE
add APK signing logic

### DIFF
--- a/docker/config.ini
+++ b/docker/config.ini
@@ -131,6 +131,12 @@ comment = Example GPG key
 key = RWRCSwAAAADUvtjCkFEF4bWWxpPBo9o8R5FK6Rz5aPUsaZONLu8kxIjud9Fd+Mgu7J2fFJDVyKFAXNH6pKS+AuBW3v+TQT5m1J0W/JYTjqzIrgAZhRtm5v3vSKRl3HUD2zEEbG5j3tg=
 comment = Example usign key
 
+[apk]
+key = -----BEGIN EC PRIVATE KEY-----
+	MHcCAQEEIIP54p1G0UgCleLObh07Gxq0S0Iz22OQpkUj8S1AzXB9oAoGCCqGSM49
+	...
+	-----END EC PRIVATE KEY-----
+
 [worker 1]
 phase = 1
 name = buildworker-phase1

--- a/docker/rsync/Dockerfile
+++ b/docker/rsync/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9
+FROM debian:12
 
 COPY docker/rsync/files/entry.sh /entry.sh
 

--- a/phase1/config.ini.example
+++ b/phase1/config.ini.example
@@ -36,6 +36,10 @@ gpg_passphrase = secret password
 gpg_comment = Unattended build signature
 usign_key = RWRCSwAAA...OihABfuLvGRVfVaJ6wLf0=
 usign_comment = Unattended build signature
+apk_key = -----BEGIN EC PRIVATE KEY-----
+	MHcCAQEEIIP54p1G0UgCleLObh07Gxq0S0Iz22OQpkUj8S1AzXB9oAoGCCqGSM49
+	...
+	-----END EC PRIVATE KEY-----
 binary_url = user@example.org::upload-binary
 binary_password = example
 source_url = user@example.org::upload-sources

--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -1370,7 +1370,8 @@ def prepareFactory(target):
                 "find bin/targets/%(kw:target)s/%(kw:subtarget)s%(prop:libc)s/ "
                 "bin/targets/%(kw:target)s/%(kw:subtarget)s%(prop:libc)s/kmods/ "
                 "-mindepth 1 -maxdepth 2 -type f -name sha256sums -print0 -or "
-                "-name Packages -print0 | xargs -0 tar -czf sign.tar.gz",
+                "-name Packages -print0 -or -name packages.adb -print0 "
+                "| xargs -0 tar -czf sign.tar.gz",
                 target=target,
                 subtarget=subtarget,
             ),

--- a/phase2/config.ini.example
+++ b/phase2/config.ini.example
@@ -46,6 +46,12 @@ comment = Unattended build signature
 key = RWRCSwAAA...OihABfuLvGRVfVaJ6wLf0=
 comment = Unattended build signature
 
+[apk]
+key = -----BEGIN EC PRIVATE KEY-----
+	MHcCAQEEIIP54p1G0UgCleLObh07Gxq0S0Iz22OQpkUj8S1AzXB9oAoGCCqGSM49
+	...
+	-----END EC PRIVATE KEY-----
+
 [worker 1]
 phase = 2
 name = worker-example-1
@@ -57,4 +63,3 @@ phase = 2
 name = worker-example-2
 password = example2
 builds = 3
-

--- a/phase2/master.cfg
+++ b/phase2/master.cfg
@@ -591,7 +591,7 @@ for arch in arches:
 			name = "signpack",
 			description = "Packing files to sign",
 			workdir = "build/sdk",
-			command = "find bin/packages/%s/ -mindepth 2 -maxdepth 2 -type f -name Packages -print0 | xargs -0 tar -czf sign.tar.gz" %(arch[0]),
+			command = "find bin/packages/%s/ -mindepth 2 -maxdepth 2 -type f -name Packages -print0 -or -name packages.adb -print0 | xargs -0 tar -czf sign.tar.gz" %(arch[0]),
 			haltOnFailure = True
 		))
 


### PR DESCRIPTION
With this commit it's possible to sign APK package indexes (packages.adb) via the `signall.sh` script, which is run on the buildmaster. As a consequence `apk` must be available on the buildmaster. This is the final step to replace OPKG with APK.