### PR TITLE
buildmaster: add static apk utility

### DIFF
--- a/docker/buildmaster/Dockerfile
+++ b/docker/buildmaster/Dockerfile
@@ -1,3 +1,28 @@
+FROM alpinelinux/build-base:latest-x86_64 AS apk-builder
+
+RUN abuild-apk add -u \
+	gcc \
+	git \
+	linux-headers \
+	lua5.3-dev \
+	lua5.3-lzlib \
+	make \
+	musl-dev \
+	openssl-dev \
+	openssl-libs-static \
+	zlib-dev \
+	zlib-static \
+	zstd-dev \
+	zstd-static
+
+ARG APK_TOOLS_COMMIT=74de0e9bd73d1af8720df40aa68d472943909804
+
+RUN git clone https://gitlab.alpinelinux.org/alpine/apk-tools.git /tmp/apk-tools
+WORKDIR /tmp/apk-tools
+RUN git checkout $APK_TOOLS_COMMIT
+RUN make -j$(nproc) static
+
+
 FROM        debian:11
 MAINTAINER  OpenWrt Maintainers
 
@@ -55,6 +80,7 @@ COPY docker/buildmaster/files/start.sh /start.sh
 COPY phase1 /phase1
 COPY phase2 /phase2
 COPY scripts /scripts
+COPY --from=apk-builder /tmp/apk-tools/src/apk.static /usr/bin/apk
 
 RUN \
     groupadd buildbot && \

--- a/tests/cram/master/02-apk.t
+++ b/tests/cram/master/02-apk.t
@@ -1,0 +1,4 @@
+Check that apk is available and usable in master container:
+
+  $ docker run --entrypoint apk local/master | grep usage
+  usage: apk [<OPTIONS>...] COMMAND [<ARGUMENTS>...]


### PR DESCRIPTION
We need apk to sign packages.adb, this is unreleased version introduced in commit ef8c1adb6118 ("apk: switch to index-trust branch"), thus not available already anywhere yet. So until its available, lets build a static version and use that meanwhile.

Fixes: a94d4e15fdc1 ("add APK signing logic")