### PR TITLE
buildworker: start: fix worker startup failure after update

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -59,10 +59,8 @@ jobs:
       matrix:
         include:
           - container_flavor: master
-            container_verify_string: "buildmaster configured in /master"
           - container_flavor: worker
-            container_test_command: "--env BUILDWORKER_NAME=X --env BUILDWORKER_PASSWORD=Y"
-            container_verify_string: "worker configured in /builder"
+            container_test_command: "--env BUILDWORKER_TLS=1 --env BUILDWORKER_MASTER=Z:1922 --env BUILDWORKER_NAME=X --env BUILDWORKER_PASSWORD=Y"
 
     steps:
       - name: Checkout

--- a/docker/buildworker/files/start.sh
+++ b/docker/buildworker/files/start.sh
@@ -12,17 +12,14 @@
 
 rm -f /builder/buildbot.tac
 
-use_tls=""
-[ "$BUILDWORKER_TLS" = 1 ] && use_tls="--use-tls"
-/opt/venv/bin/buildbot-worker create-worker --force --umask="0o22" $use_tls /builder \
-    "$BUILDWORKER_MASTER" "$BUILDWORKER_NAME" "$BUILDWORKER_PASSWORD"
-
-if [ "$BUILDWORKER_TLS" = 1 ]; then
-	sed -i \
-		-e 's#(buildmaster_host, port, #(None, None, #' \
-		-e 's#allow_shutdown=allow_shutdown#&, connection_string="SSL:%s:%d" %(buildmaster_host, port)#' \
-		/builder/buildbot.tac
-fi
+/opt/venv/bin/buildbot-worker create-worker \
+	--force \
+	--umask="0o22" \
+	--connection-string="SSL:$BUILDWORKER_MASTER" \
+	/builder \
+	"$BUILDWORKER_MASTER" \
+	"$BUILDWORKER_NAME" \
+	"$BUILDWORKER_PASSWORD"
 
 echo "$BUILDWORKER_ADMIN" > /builder/info/admin
 echo "$BUILDWORKER_DESCRIPTION" > /builder/info/host


### PR DESCRIPTION
### buildworker: start: fix worker startup failure after update

Workers are currently refusing to work:

```python
 Unhandled Error
 Traceback (most recent call last):
   File "/opt/venv/lib/python3.11/site-packages/twisted/application/app.py", line 673, in run
     runApp(config)
   File "/opt/venv/lib/python3.11/site-packages/twisted/scripts/twistd.py", line 29, in runApp
     runner.run()
   File "/opt/venv/lib/python3.11/site-packages/twisted/application/app.py", line 370, in run
     self.application = self.createOrGetApplication()
   File "/opt/venv/lib/python3.11/site-packages/twisted/application/app.py", line 437, in createOrGetApplication
     application = getApplication(self.config, passphrase)
 --- <exception caught here> ---
   File "/opt/venv/lib/python3.11/site-packages/twisted/application/app.py", line 446, in getApplication
     application = service.loadApplication(filename, style, passphrase)
   File "/opt/venv/lib/python3.11/site-packages/twisted/application/service.py", line 404, in loadApplication
     application = sob.loadValueFromFile(filename, "application")
   File "/opt/venv/lib/python3.11/site-packages/twisted/persisted/sob.py", line 174, in loadValueFromFile
     codeObj = compile(data, filename, "exec")
 builtins.SyntaxError: keyword argument repeated: connection_string (buildbot.tac, line 49)
```

as the buildbot.tac template changed in commit 4ba1dcb66155 ("worker:
Add option --connection-string for create-worker") and version v3.10.0.

So lets use this new `--connection-string` feature and get rid of the
sed-fu.

Fixes: efbddc90d8e6 ("Bump buildbot to v3.11.1 release")

### ci: fix worker startup issue by adding missing env vars and cleanup unused vars

Workers are currently refusing to work:

```python
  Unhandled Error
  Traceback (most recent call last):
    File "/opt/venv/lib/python3.11/site-packages/twisted/application/app.py", line 673, in run
      runApp(config)
    File "/opt/venv/lib/python3.11/site-packages/twisted/scripts/twistd.py", line 29, in runApp
      runner.run()
    File "/opt/venv/lib/python3.11/site-packages/twisted/application/app.py", line 370, in run
      self.application = self.createOrGetApplication()
    File "/opt/venv/lib/python3.11/site-packages/twisted/application/app.py", line 437, in createOrGetApplication
      application = getApplication(self.config, passphrase)
  --- <exception caught here> ---
    File "/opt/venv/lib/python3.11/site-packages/twisted/application/app.py", line 446, in getApplication
      application = service.loadApplication(filename, style, passphrase)
    File "/opt/venv/lib/python3.11/site-packages/twisted/application/service.py", line 404, in loadApplication
      application = sob.loadValueFromFile(filename, "application")
    File "/opt/venv/lib/python3.11/site-packages/twisted/persisted/sob.py", line 174, in loadValueFromFile
      codeObj = compile(data, filename, "exec")
  builtins.SyntaxError: keyword argument repeated: connection_string (buildbot.tac, line 49)
```

and we're not aware about it, so lets fix it by adding the same
environment variables we're actually using in production.

While at it, cleanup the unused container_verify_string variables.

Fixed (failing) CI test is visible here https://github.com/openwrt/buildbot/actions/runs/11060475202/job/30731095086#step:5:48