### PR TITLE
docker: buildworker: add missing file package

### DIFF
--- a/docker/buildworker/Dockerfile
+++ b/docker/buildworker/Dockerfile
@@ -17,6 +17,7 @@ RUN \
 		build-essential \
 		ccache \
 		curl \
+		file \
 		gawk \
 		g++-multilib \
 		gcc-multilib \


### PR DESCRIPTION
In Debian 11 (Bullseye), the `file` package was installed indirectly because the `man-db` package recommended it. The `man-db` package is often installed as a dependency of other packages, such as `build-essential` and tools like `gcc` and `make`.  By default, `apt-get` installs recommended packages, so `file` was installed automatically.

Starting from Debian 12 (Bookworm), the `man-db` package no longer recommends the `file` package. This change was made to reduce the size of minimal container images and installations where `file` is not essential.

So lets install this package explicitly.