### PR TITLE
phase2: signpack: fix sha256sums signatures of apk packages.adb index

### DIFF
--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -368,7 +368,7 @@ c["change_source"].append(
         workdir=work_dir + "/work.git",
         branches=branchNames,
         pollAtLaunch=True,
-        pollinterval=300,
+        pollInterval=300,
     )
 )
 

--- a/phase2/master.cfg
+++ b/phase2/master.cfg
@@ -179,7 +179,7 @@ def parse_feed_entry(line):
 		url = parts[2].strip().split(';')
 		branch = url[1] if len(url) > 1 else 'main'
 		feedbranches[url[0]] = branch
-		c['change_source'].append(GitPoller(url[0], branch=branch, workdir='%s/%s.git' %(os.getcwd(), parts[1]), pollinterval=300))
+		c['change_source'].append(GitPoller(url[0], branch=branch, workdir='%s/%s.git' %(os.getcwd(), parts[1]), pollInterval=300))
 
 make = subprocess.Popen(['make', '--no-print-directory', '-C', work_dir+'/source.git/target/sdk/', 'val.BASE_FEED'],
 	env = dict(os.environ, TOPDIR=work_dir+'/source.git'), stdout = subprocess.PIPE)

--- a/phase2/master.cfg
+++ b/phase2/master.cfg
@@ -591,7 +591,10 @@ for arch in arches:
 			name = "signpack",
 			description = "Packing files to sign",
 			workdir = "build/sdk",
-			command = "find bin/packages/%s/ -mindepth 2 -maxdepth 2 -type f -name Packages -print0 -or -name packages.adb -print0 | xargs -0 tar -czf sign.tar.gz" %(arch[0]),
+			command = "find bin/packages/%s/ -mindepth 2 -maxdepth 2 -type f " %(arch[0])
+			+ "-name Packages -print0 -or "
+			+ "-name packages.adb -print0 | "
+			+ "xargs -0 tar -czf sign.tar.gz",
 			haltOnFailure = True
 		))
 

--- a/phase2/master.cfg
+++ b/phase2/master.cfg
@@ -591,7 +591,8 @@ for arch in arches:
 			name = "signpack",
 			description = "Packing files to sign",
 			workdir = "build/sdk",
-			command = "find bin/packages/%s/ -mindepth 2 -maxdepth 2 -type f " %(arch[0])
+			command = "find bin/packages/%s/ -mindepth 1 -maxdepth 2 -type f " %(arch[0])
+			+ "-name sha256sums -print0 -or "
 			+ "-name Packages -print0 -or "
 			+ "-name packages.adb -print0 | "
 			+ "xargs -0 tar -czf sign.tar.gz",


### PR DESCRIPTION
Currently the sha256sum verification of apk's packages.adb index
fails as the file is modified with `apk adbsign`, but we currently don't
send the sha256sums file to the master, thus it can't be fixed during
signing.

So lets pack sha256sums files and ship them to master for proper
signing.

Fixes: https://github.com/openwrt/buildbot/commit/a94d4e15fdc1e9715d7d0cfdcc62227186d0fc45 ("add APK signing logic")