### PR TITLE
buildworker: start: fix broken non TLS setups

### DIFF
--- a/docker/buildworker/files/start.sh
+++ b/docker/buildworker/files/start.sh
@@ -21,7 +21,7 @@ rm -f /builder/buildbot.tac
 /opt/venv/bin/buildbot-worker create-worker \
 	--force \
 	--umask="0o22" \
-	--connection-string="${BUILDWORKER_TLS:+SSL:}$BUILDWORKER_MASTER" \
+	${BUILDWORKER_TLS:+--connection-string="SSL:$BUILDWORKER_MASTER"} \
 	/builder \
 	"$BUILDWORKER_MASTER" \
 	"$BUILDWORKER_NAME" \

--- a/docker/buildworker/files/start.sh
+++ b/docker/buildworker/files/start.sh
@@ -21,7 +21,7 @@ rm -f /builder/buildbot.tac
 /opt/venv/bin/buildbot-worker create-worker \
 	--force \
 	--umask="0o22" \
-	--connection-string="SSL:$BUILDWORKER_MASTER" \
+	--connection-string="${BUILDWORKER_TLS:+SSL:}$BUILDWORKER_MASTER" \
 	/builder \
 	"$BUILDWORKER_MASTER" \
 	"$BUILDWORKER_NAME" \

--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -368,7 +368,7 @@ c["change_source"].append(
         workdir=work_dir + "/work.git",
         branches=branchNames,
         pollAtLaunch=True,
-        pollinterval=300,
+        pollInterval=300,
     )
 )
 

--- a/phase2/master.cfg
+++ b/phase2/master.cfg
@@ -179,7 +179,7 @@ def parse_feed_entry(line):
 		url = parts[2].strip().split(';')
 		branch = url[1] if len(url) > 1 else 'main'
 		feedbranches[url[0]] = branch
-		c['change_source'].append(GitPoller(url[0], branch=branch, workdir='%s/%s.git' %(os.getcwd(), parts[1]), pollinterval=300))
+		c['change_source'].append(GitPoller(url[0], branch=branch, workdir='%s/%s.git' %(os.getcwd(), parts[1]), pollInterval=300))
 
 make = subprocess.Popen(['make', '--no-print-directory', '-C', work_dir+'/source.git/target/sdk/', 'val.BASE_FEED'],
 	env = dict(os.environ, TOPDIR=work_dir+'/source.git'), stdout = subprocess.PIPE)


### PR DESCRIPTION
Changes in commit 3812ff7bb296 ("buildworker: start: fix worker startup failure after update") broke non TLS setups. So lets fix it by setting SSL: only if BUILDWORKER_TLS is set.

Fixes: 3812ff7bb296 ("buildworker: start: fix worker startup failure after update")
Reported-by: Paul Spooren <mail@aparcar.org>