### PR TITLE
docker,worker: install pyelftools

### DIFF
--- a/docker/buildworker/Dockerfile
+++ b/docker/buildworker/Dockerfile
@@ -33,6 +33,7 @@ RUN \
 		python3 \
 		python3-venv \
 		python3-pip \
+		python3-pyelftools \
 		qemu-utils \
 		rsync \
 		signify-openbsd \


### PR DESCRIPTION
Without it, errors may appear:

WARNING: Makefile 'package/feeds/telephony/freeswitch/Makefile' has a dependency on 'libpcre', which does not exist make[2]: Entering directory '/builder/shared-workdir/build/scripts/config' make[2]: 'conf' is up to date.
make[2]: Leaving directory '/builder/shared-workdir/build/scripts/config' Checking 'python3-pyelftools'... failed.
Checking 'python3-dev'... ok.
Checking 'python3-setuptools'... ok.
Checking 'swig'... ok.
u-boot: Please install the Python3 elftools module