### PR TITLE
Switch back to Debian 11 as a base system

### DIFF
--- a/docker/buildmaster/Dockerfile
+++ b/docker/buildmaster/Dockerfile
@@ -23,7 +23,7 @@ RUN git checkout $APK_TOOLS_COMMIT
 RUN make -j$(nproc) static
 
 
-FROM        debian:12
+FROM        debian:11
 MAINTAINER  OpenWrt Maintainers
 
 ARG         DEBIAN_FRONTEND=noninteractive

--- a/docker/buildworker/Dockerfile
+++ b/docker/buildworker/Dockerfile
@@ -1,4 +1,4 @@
-FROM        debian:12
+FROM        debian:11
 MAINTAINER  OpenWrt Maintainers
 
 ARG         DEBIAN_FRONTEND=noninteractive

--- a/docker/buildworker/files/start.sh
+++ b/docker/buildworker/files/start.sh
@@ -21,7 +21,7 @@ rm -f /builder/buildbot.tac
 /opt/venv/bin/buildbot-worker create-worker \
 	--force \
 	--umask="0o22" \
-	--connection-string="SSL:$BUILDWORKER_MASTER" \
+	--connection-string="${BUILDWORKER_TLS:+SSL:}$BUILDWORKER_MASTER" \
 	/builder \
 	"$BUILDWORKER_MASTER" \
 	"$BUILDWORKER_NAME" \


### PR DESCRIPTION
 * Revert "buildworker,buildmaster: bump Debian to version 12"
 * buildworker: start: fix broken non TLS setups