### PR TITLE
phase2: support multiple branch in parse_feed_entry and SingleBranchS…

### DIFF
--- a/phase2/master.cfg
+++ b/phase2/master.cfg
@@ -177,9 +177,9 @@ def parse_feed_entry(line):
 	if parts[0].startswith("src-git"):
 		feeds.append(parts)
 		url = parts[2].strip().split(';')
-		branch = url[1] if len(url) > 1 else 'main'
-		feedbranches[url[0]] = branch
-		c['change_source'].append(GitPoller(url[0], branch=branch, workdir='%s/%s.git' %(os.getcwd(), parts[1]), pollInterval=300))
+		branches = [url[1]] if len(url) > 1 else ['main', 'master']
+		feedbranches[url[0]] = branches
+		c['change_source'].append(GitPoller(url[0], branches=branches, workdir='%s/%s.git' %(os.getcwd(), parts[1]), pollInterval=300))
 
 make = subprocess.Popen(['make', '--no-print-directory', '-C', work_dir+'/source.git/target/sdk/', 'val.BASE_FEED'],
 	env = dict(os.environ, TOPDIR=work_dir+'/source.git'), stdout = subprocess.PIPE)
@@ -205,7 +205,7 @@ c['schedulers'] = []
 c['schedulers'].append(SingleBranchScheduler(
 	name            = "all",
 	change_filter   = filter.ChangeFilter(
-		filter_fn = lambda change: change.branch == feedbranches[change.repository]
+		filter_fn = lambda change: change.branch in feedbranches[change.repository]
 	),
 	treeStableTimer = 60,
 	builderNames    = archnames))


### PR DESCRIPTION
…cheduler

Add support for multiple branch in parse_feed_entry and SingleBranchScheduler.

- Moving to GitPoller branches
- Change feedbranches to define an array of branches
- Update the filter_fn to check multiple entry in feedbranches