### PR TITLE
docker,worker: install python3-cryptography

### DIFF
--- a/docker/buildworker/Dockerfile
+++ b/docker/buildworker/Dockerfile
@@ -34,6 +34,7 @@ RUN \
 		python3-venv \
 		python3-pip \
 		python3-pyelftools \
+		python3-cryptography \
 		qemu-utils \
 		rsync \
 		signify-openbsd \


### PR DESCRIPTION
Addition of OPTEE support along with STM32 added a requirment on python3-cryptography and without it buildbots for STM32 will fail with:
```
Checking 'python3-cryptography'... failed.
Checking 'python3-pyelftools'... ok.
optee-os: Please install the Python3 cryptography module make[3]: *** [/builder/shared-workdir/build/include/prereq.mk:9: prereq] Error 1
```

So install python3-cryptography to satisfy it.