### PR TITLE
phase1: fix signing steps when only apk_key is defined

### DIFF
--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -88,7 +88,9 @@ def ini_parse_branch(section):
     b["src_url"] = section.get("source_url")
     b["src_key"] = section.get("source_password")
 
+    b["apk_key"] = section.get("apk_key")
     b["gpg_key"] = section.get("gpg_key")
+    b["gpg_keyid"] = section.get("gpg_keyid")
 
     b["usign_key"] = section.get("usign_key")
     usign_comment = "untrusted comment: " + name.replace("-", " ").title() + " key"
@@ -573,9 +575,24 @@ def IsUsignEnabled(step):
     return branch and branches[branch].get("usign_key")
 
 
-def IsSignEnabled(step):
+def IsApkSigningEnabled(step):
     branch = step.getProperty("branch")
-    return IsUsignEnabled(step) or branch and branches[branch].get("gpg_key")
+    return branch and branches[branch].get("apk_key")
+
+
+# gpg_key - contains the key in PGP format
+# gpg_keyid - contains the keyid of the key on the nk3 dongle
+def IsGpgSigningEnabled(step):
+    branch = step.getProperty("branch")
+    return branch and (
+        branches[branch].get("gpg_key") or branches[branch].get("gpg_keyid")
+    )
+
+
+def IsSignEnabled(step):
+    return (
+        IsUsignEnabled(step) or IsApkSigningEnabled(step) or IsGpgSigningEnabled(step)
+    )
 
 
 def IsKmodArchiveEnabled(step):


### PR DESCRIPTION
Signing steps are currently skipped if only `apk_key` is configured for a branch, because `IsSignEnabled` only checks for `usign_key` or `gpg_key`.

Fix this by explicitly checking for `apk_key`.

While at it, refactor the signing checks into dedicated helper functions `IsApkSigningEnabled` and `IsGpgSigningEnabled` for better readability.