### PR TITLE
phase1: fix CONFIG_SIGNED_PACKAGES for apk signing

### DIFF
--- a/phase1/master.cfg
+++ b/phase1/master.cfg
@@ -650,6 +650,15 @@ def GetUsignKey(props):
     return branch and branches[branch].get("usign_key")
 
 
+@util.renderer
+def IsSignedPackagesEnabled(props):
+    branch = props.getProperty("branch")
+    if not branch:
+        return False
+    b = branches.get(branch, {})
+    return bool(b.get("usign_key") or b.get("apk_key"))
+
+
 def GetNextBuild(builder, requests):
     for r in requests:
         if r.properties:
@@ -1018,10 +1027,10 @@ def prepareFactory(target):
             command=Interpolate(
                 "printf 'CONFIG_TARGET_%(kw:target)s=y\\n"
                 "CONFIG_TARGET_%(kw:target)s_%(kw:subtarget)s=y\\n"
-                "CONFIG_SIGNED_PACKAGES=%(kw:usign:#?|y|n)s\\n' >> .config",
+                "CONFIG_SIGNED_PACKAGES=%(kw:signed:#?|y|n)s\\n' >> .config",
                 target=target,
                 subtarget=subtarget,
-                usign=GetUsignKey,
+                signed=IsSignedPackagesEnabled,
             ),
         )
     )


### PR DESCRIPTION
Currently `CONFIG_SIGNED_PACKAGES` is only enabled when `usign_key` is configured. However, we also want to enable it when `apk_key` is configured, as we support signing APK packages as well.

So lets fix it by adding `IsSignedPackagesEnabled` helper which checks for both keys and updates the .config generation to use it.