### PR TITLE
phase2: fix signing steps when only apk_key is defined

### DIFF
--- a/phase2/master.cfg
+++ b/phase2/master.cfg
@@ -303,6 +303,22 @@ def UsignSec2Pub(seckey, comment="untrusted comment: secret key"):
 def IsSharedWorkdir(step):
 	return bool(step.getProperty("shared_wd"))
 
+def IsUsignEnabled(step):
+	return ini.has_option("usign", "key")
+
+def IsApkSigningEnabled(step):
+	return ini.has_option("apk", "key")
+
+# gpg_key - contains the key in PGP format
+# gpg_keyid - contains the keyid of the key on the nk3
+def IsGpgSigningEnabled(step):
+	return ini.has_option("gpg", "key") or ini.has_option("gpg", "keyid")
+
+def IsSignEnabled(step):
+	return (
+		IsUsignEnabled(step) or IsApkSigningEnabled(step) or IsGpgSigningEnabled(step)
+	)
+
 @defer.inlineCallbacks
 def getNewestCompleteTime(bldr):
 	"""Returns the complete_at of the latest completed and not SKIPPED
@@ -485,24 +501,26 @@ for arch in arches:
 		command = ["make", "-f", "getversion.mk"]))
 
 	# install build key
-	if usign_key is not None:
-		factory.addStep(StringDownload(
-			name = "dlkeybuildpub",
-			s = UsignSec2Pub(usign_key, usign_comment),
-			workerdest = "sdk/key-build.pub",
-			mode = 0o600))
+	factory.addStep(StringDownload(
+		name = "dlkeybuildpub",
+		s = UsignSec2Pub(usign_key, usign_comment),
+		workerdest = "sdk/key-build.pub",
+		mode = 0o600,
+		doStepIf = IsUsignEnabled))
 
-		factory.addStep(StringDownload(
-			name = "dlkeybuild",
-			s = "# fake private key",
-			workerdest = "sdk/key-build",
-			mode = 0o600))
+	factory.addStep(StringDownload(
+		name = "dlkeybuild",
+		s = "# fake private key",
+		workerdest = "sdk/key-build",
+		mode = 0o600,
+		doStepIf = IsUsignEnabled))
 
-		factory.addStep(StringDownload(
-			name = "dlkeybuilducert",
-			s = "# fake certificate",
-			workerdest = "sdk/key-build.ucert",
-			mode = 0o600))
+	factory.addStep(StringDownload(
+		name = "dlkeybuilducert",
+		s = "# fake certificate",
+		workerdest = "sdk/key-build.ucert",
+		mode = 0o600,
+		doStepIf = IsUsignEnabled))
 
 	factory.addStep(ShellCommand(
 		name = "mkdldir",
@@ -579,53 +597,58 @@ for arch in arches:
 		haltOnFailure = True
 	))
 
-	if ini.has_option("gpg", "key") or usign_key is not None:
-		factory.addStep(MasterShellCommand(
-			name = "signprepare",
-			description = "Preparing temporary signing directory",
-			command = ["mkdir", "-p", "%s/signing" %(work_dir)],
-			haltOnFailure = True
-		))
+	factory.addStep(MasterShellCommand(
+		name = "signprepare",
+		description = "Preparing temporary signing directory",
+		command = ["mkdir", "-p", "%s/signing" %(work_dir)],
+		haltOnFailure = True,
+		doStepIf = IsSignEnabled
+	))
 
-		factory.addStep(ShellCommand(
-			name = "signpack",
-			description = "Packing files to sign",
-			workdir = "build/sdk",
-			command = "find bin/packages/%s/ -mindepth 1 -maxdepth 2 -type f " %(arch[0])
-			+ "-name sha256sums -print0 -or "
-			+ "-name Packages -print0 -or "
-			+ "-name packages.adb -print0 | "
-			+ "xargs -0 tar -czf sign.tar.gz",
-			haltOnFailure = True
-		))
+	factory.addStep(ShellCommand(
+		name = "signpack",
+		description = "Packing files to sign",
+		workdir = "build/sdk",
+		command = "find bin/packages/%s/ -mindepth 1 -maxdepth 2 -type f " %(arch[0])
+		+ "-name sha256sums -print0 -or "
+		+ "-name Packages -print0 -or "
+		+ "-name packages.adb -print0 | "
+		+ "xargs -0 tar -czf sign.tar.gz",
+		haltOnFailure = True,
+		doStepIf = IsSignEnabled
+	))
 
-		factory.addStep(FileUpload(
-			workersrc = "sdk/sign.tar.gz",
-			masterdest = "%s/signing/%s.tar.gz" %(work_dir, arch[0]),
-			haltOnFailure = True
-		))
+	factory.addStep(FileUpload(
+		workersrc = "sdk/sign.tar.gz",
+		masterdest = "%s/signing/%s.tar.gz" %(work_dir, arch[0]),
+		haltOnFailure = True,
+		doStepIf = IsSignEnabled
+	))
 
-		factory.addStep(MasterShellCommand(
-			name = "signfiles",
-			description = "Signing files",
-			command = ["%s/signall.sh" %(scripts_dir), "%s/signing/%s.tar.gz" %(work_dir, arch[0])],
-			env = { 'CONFIG_INI': os.getenv("BUILDMASTER_CONFIG", "./config.ini") },
-			haltOnFailure = True
-		))
+	factory.addStep(MasterShellCommand(
+		name = "signfiles",
+		description = "Signing files",
+		command = ["%s/signall.sh" %(scripts_dir), "%s/signing/%s.tar.gz" %(work_dir, arch[0])],
+		env = { 'CONFIG_INI': os.getenv("BUILDMASTER_CONFIG", "./config.ini") },
+		haltOnFailure = True,
+		doStepIf = IsSignEnabled
+	))
 
-		factory.addStep(FileDownload(
-			mastersrc = "%s/signing/%s.tar.gz" %(work_dir, arch[0]),
-			workerdest = "sdk/sign.tar.gz",
-			haltOnFailure = True
-		))
+	factory.addStep(FileDownload(
+		mastersrc = "%s/signing/%s.tar.gz" %(work_dir, arch[0]),
+		workerdest = "sdk/sign.tar.gz",
+		haltOnFailure = True,
+		doStepIf = IsSignEnabled
+	))
 
-		factory.addStep(ShellCommand(
-			name = "signunpack",
-			description = "Unpacking signed files",
-			workdir = "build/sdk",
-			command = ["tar", "-xzf", "sign.tar.gz"],
-			haltOnFailure = True
-		))
+	factory.addStep(ShellCommand(
+		name = "signunpack",
+		description = "Unpacking signed files",
+		workdir = "build/sdk",
+		command = ["tar", "-xzf", "sign.tar.gz"],
+		haltOnFailure = True,
+		doStepIf = IsSignEnabled
+	))
 
 	# download remote sha256sums to 'target-sha256sums'
 	factory.addStep(ShellCommand(


### PR DESCRIPTION
Signing steps are currently skipped if only APK signing is configured, because phase2 effectively enables signing only when `usign` is present.

Fix this by making `IsSignEnabled` explicitly cover APK signing too.

While at it, refactor the signing checks into dedicated helper functions `IsUsignEnabled`, `IsApkSigningEnabled`, and `IsGpgSigningEnabled`, and use them consistently to align phase2 with the phase1 implementation.