### PR TITLE
Docker: update to Debian Trixie and add shfmt

### DIFF
--- a/docker/buildmaster/Dockerfile
+++ b/docker/buildmaster/Dockerfile
@@ -23,7 +23,7 @@ RUN git checkout $APK_TOOLS_COMMIT
 RUN make -j$(nproc) static
 
 
-FROM        debian:11
+FROM        debian:13
 LABEL       maintainer="OpenWrt Maintainers"
 
 ARG         DEBIAN_FRONTEND=noninteractive
@@ -41,8 +41,9 @@ RUN \
 		build-essential \
 		gawk \
 		git-core \
+		gnupg \
 		gosu \
-		libncurses5-dev \
+		libncurses-dev \
 		locales \
 		pv \
 		pwgen \
@@ -65,7 +66,8 @@ RUN \
 		"buildbot-grid-view==$BUILDBOT_VERSION" \
 		"buildbot-worker==$BUILDBOT_VERSION" \
 		pyOpenSSL \
-		service_identity
+		service_identity \
+		legacy-cgi
 
 RUN \
 	sed -i \

--- a/docker/buildworker/Dockerfile
+++ b/docker/buildworker/Dockerfile
@@ -1,4 +1,4 @@
-FROM        debian:11
+FROM        debian:13
 LABEL       maintainer="OpenWrt Maintainers"
 
 ARG         DEBIAN_FRONTEND=noninteractive
@@ -24,10 +24,11 @@ RUN \
 		gcc-multilib \
 		genisoimage \
 		git-core \
+		gnupg \
 		gosu \
 		libdw-dev \
 		libelf-dev \
-		libncurses5-dev \
+		libncurses-dev \
 		locales \
 		pv \
 		pwgen \
@@ -54,7 +55,9 @@ RUN pip3 install \
 		"buildbot-worker==$BUILDBOT_VERSION" \
 		pyelftools \
 		pyOpenSSL \
-		service_identity
+		service_identity \
+		legacy-cgi
+
 
 ENV LANG=en_US.utf8
 

--- a/docker/buildworker/Dockerfile
+++ b/docker/buildworker/Dockerfile
@@ -40,6 +40,7 @@ RUN \
 		qemu-utils \
 		rsync \
 		signify-openbsd \
+		shfmt \
 		subversion \
 		swig \
 		unzip \


### PR DESCRIPTION
Regarding the update to the latest Debian version: since support for Debian 11, which is currently used here, is ending soon, I have updated it to Debian 13. This also solves the issue with the shfmt package, which is not available in Debian 11. shfmt is needed because our CI/CD pipeline fails from time to time.

As can be seen here:
https://github.com/openwrt/packages/pull/29398#issuecomment-4438521229 and https://github.com/openwrt/packages/pull/29803#issuecomment-4787551913

The hard dependency on shfmt was added in this pull request:
https://github.com/openwrt/gh-action-sdk/pull/4 4 years ago

Also adds hard dependency for **gnupg**
```
#28 [stage-1 15/15] RUN 	mkdir -p /home/buildbot && 	chmod u=rwx,go= /home/buildbot && 	chown --recursive buildbot:buildbot /home/buildbot && 	gosu buildbot sh -c "gpg --homedir /home/buildbot/.gnupg --recv-keys 0x1D53D1877742E911"
#28 0.167 sh: 1: gpg: not found
#28 ERROR: process "/bin/sh -c mkdir -p /home/buildbot && \tchmod u=rwx,go= /home/buildbot && \tchown --recursive buildbot:buildbot /home/buildbot && \tgosu buildbot sh -c \"gpg --homedir /home/buildbot/.gnupg --recv-keys 0x1D53D1877742E911\"" did not complete successfully: exit code: 127
```

cc: @aparcar 